### PR TITLE
All 3 tasks fixes

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Transaction;
+
 class TransactionController extends Controller
 {
+
     public function index()
     {
-        $transactions = \App\Models\Transaction::with('user')->get();
+        $transactions = Transaction::with('user')->get();
 
         return view('transactions.index', compact('transactions'));
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,12 +16,12 @@ use App\Http\Controllers\TransactionController;
 
 Route::redirect('/', '/transactions');
 
-Route::get('transactions/{transactions}/export',
+Route::get('transactions/{transaction}/export',
     [TransactionController::class, 'export'])
     ->name('transactions.export');
 
 Route::resource('transactions', TransactionController::class);
 
-Route::get('transactions/{transaction}/duplicate',
+Route::get('transactions/{transaction:uuid}/duplicate',
     [TransactionController::class, 'duplicate'])
     ->name('transactions.duplicate');


### PR DESCRIPTION
Task 1 Solution: 
we need to add the full path of class or we can specify the name space of the modal class.

Task 2 Solution: 
if we route using route model binding we need to pass single object as query parameter in the web.php
like 'transactions' to single 'transaction'.

Task 3 Solution: 
if we not specify any of column in web.php route, it will use 'id' by default..
in our case we need to define uuid column "transaction:uuid" other wise this will search by id.

