### PR TITLE
#1, #2 and #3 done 

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -8,7 +8,7 @@ class TransactionController extends Controller
 {
     public function index()
     {
-        $transactions = \App\Models\Transaction::with('user')->get();
+        $transactions = Transaction::with('user')->get();
 
         return view('transactions.index', compact('transactions'));
     }

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use \App\Models\Transaction;
+
 class TransactionController extends Controller
 {
     public function index()

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
 
 class Transaction extends Model
 {

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@ use App\Http\Controllers\TransactionController;
 
 Route::redirect('/', '/transactions');
 
-Route::get('transactions/{transactions}/export',
+Route::get('transactions/{transaction}/export',
     [TransactionController::class, 'export'])
     ->name('transactions.export');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,6 @@ Route::get('transactions/{transactions}/export',
 
 Route::resource('transactions', TransactionController::class);
 
-Route::get('transactions/{transaction}/duplicate',
+Route::get('transactions/{transaction:uuid}/duplicate',
     [TransactionController::class, 'duplicate'])
     ->name('transactions.duplicate');


### PR DESCRIPTION
Honestly #2 is something that annoys me with laravel, it can open so many ways of mistakes undetected by IDE and tools (that i know of).
I feel like those sort of things should be cought by some semantic checker.
Or rather, it has to made more clear in the route probably that this is supposed to be a model binding. (see #3 for example)

I mean #1 get's outlined by hopefully most IDEs.

For #3 i guess would be harder but i guess with a syntax like this, it might be easier to catch for tools and humans:
```
Route::get(['transactions', '{transaction}', 'duplicate'],
    [TransactionController::class, 'duplicate'])
    ->where('transaction', [App\Model\Transaction::class, 'uuid'])
    ->name('transactions.duplicate');
```

Just like the improvement from `Route::get('x', 'MyController@x')` to `Rouge::get('x',[MyController::class, 'x']`