### PR TITLE
Fixed

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Transaction;
+
 class TransactionController extends Controller
 {
     public function index()
     {
-        $transactions = \App\Models\Transaction::with('user')->get();
+        $transactions = Transaction::with('user')->get();
 
         return view('transactions.index', compact('transactions'));
     }

--- a/resources/views/transactions/notfound.blade.php
+++ b/resources/views/transactions/notfound.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <div class="alert alert-danger py-2">
+                <a type="button" class="btn btn-info" href="{{ url('/') }}">Back</a>
+                Not found
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,12 +16,21 @@ use App\Http\Controllers\TransactionController;
 
 Route::redirect('/', '/transactions');
 
-Route::get('transactions/{transactions}/export',
+Route::get('transactions/{transaction}/export',
     [TransactionController::class, 'export'])
-    ->name('transactions.export');
+    ->name('transactions.export')
+    ->missing(function(){
+        return response()->view('transactions.notfound');
+    });
 
-Route::resource('transactions', TransactionController::class);
+Route::resource('transactions', TransactionController::class)
+    ->missing(function(){
+        return response()->view('transactions.notfound');
+    });
 
-Route::get('transactions/{transaction}/duplicate',
+Route::get('transactions/{transaction:uuid}/duplicate',
     [TransactionController::class, 'duplicate'])
-    ->name('transactions.duplicate');
+    ->name('transactions.duplicate')
+    ->missing(function(){
+        return view('transactions.notfound');
+    });


### PR DESCRIPTION
Something that did not work form me:
1. Had to run this
composer install --ignore-platform-reqs
instead of just composer install because of this errro:
"Problem 1
    - laravel/horizon is locked to version v5.7.9 and an update of this package was not requested.
    - laravel/horizon v5.7.9 requires ext-pcntl * -> it is missing from your system. Install or enable PHP's pcntl extension.  "

2. When i wanted to add not found page returning just view('transactions.notfound'); returned an error:
"Error
Call to a member function setCookie() on null".

So this fixed: response()-> view('transactions.notfound');